### PR TITLE
Adding barGap and barSizeRatio

### DIFF
--- a/client/src/app/modules/angular-morris/directives/barChart.directive.js
+++ b/client/src/app/modules/angular-morris/directives/barChart.directive.js
@@ -39,7 +39,10 @@
             // They are part of the base grid: https://github.com/morrisjs/morris.js/blob/master/lib/morris.grid.coffee
             'ymax', 'ymin', 'goals', 'goalStrokeWidth',
             'goalLineColors', 'yLabelAlign', 'parseTime', 'postUnits', 'preUnits',
-            'xLabelAngle', 'yLabelFormat', 'events', 'eventStrokeWidth', 'eventLineColors'
+            'xLabelAngle', 'yLabelFormat', 'events', 'eventStrokeWidth', 'eventLineColors',
+            // Adding barGap and barSizeRatio
+            'barGap','barSizeRatio'
+            
         ];
 
         return {


### PR DESCRIPTION
Adding configuration options barGap and barSizeRatio. They exist in morris but can't be called from angular-morris today.